### PR TITLE
fix(ci): checkout repo before using local composite actions in on_new_pr workflow

### DIFF
--- a/.github/workflows/on_new_pr.yml
+++ b/.github/workflows/on_new_pr.yml
@@ -28,6 +28,18 @@ jobs:
     # Specifically check that dependabot (or another trusted party) created this pull-request, and that it has been labelled correctly.
     if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
+      - name: "Initialise Workspace"
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: sudo chown -R "$USER:$USER" "$GITHUB_WORKSPACE"
+
+      - name: "Checkout Source"
+        uses: actions/checkout@v6.0.3
+        with:
+          clean: true
+          fetch-depth: 1
+          ref: ${{github.event.pull_request.base.sha}}
+
       - name: "Auto Merge"
         uses: ./.github/actions/enable-automerge
         with:
@@ -43,6 +55,18 @@ jobs:
 
     if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
+      - name: "Initialise Workspace"
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: sudo chown -R "$USER:$USER" "$GITHUB_WORKSPACE"
+
+      - name: "Checkout Source"
+        uses: actions/checkout@v6.0.3
+        with:
+          clean: true
+          fetch-depth: 1
+          ref: ${{github.event.pull_request.base.sha}}
+
       - name: "Auto Approve"
         uses: ./.github/actions/approve-pr
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 -->
 
 ## [Unreleased]
+### Security
 ### Added
 ### Fixed
+- CI: Fix on_new_pr workflow to checkout repo before using local composite actions
 ### Changed
+### Deprecated
 ### Removed
 ### Deployment Changes
-
 <!--
 Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
 -->


### PR DESCRIPTION
## Summary

- Fixed `on_new_pr.yml`: both `enable-auto-merge` and `auto_approve_dependabot` jobs now checkout the repository (at base SHA) before using local composite actions `./.github/actions/enable-automerge` and `./.github/actions/approve-pr`
- Fixed `CHANGELOG.md` structure: added missing `### Security` and `### Deprecated` sections; removed blank line after `### Deployment Changes` heading

## Background

The `on_new_pr.yml` workflow uses `pull_request_target` and previously tried to use local composite actions without first running `actions/checkout`. Since `pull_request_target` workflows run with an empty workspace, the actions were not found — causing both `auto_approve_dependabot` and `enable-auto-merge` CI checks to fail on all dependency PRs.

The CHANGELOG format issues caused the `valid-changelog` CI check to fail on all PRs including Dependabot PR #356.

## Test plan

- [ ] Verify `auto_approve_dependabot` and `enable-auto-merge` checks pass on next dependency PR
- [ ] Verify `valid-changelog` check passes on this PR and on PR #356 after rebase